### PR TITLE
Remove memoized_method decorator from the generator functions

### DIFF
--- a/src/hope_flex_fields/models/datachecker.py
+++ b/src/hope_flex_fields/models/datachecker.py
@@ -58,7 +58,6 @@ class DataChecker(ValidatorMixin, models.Model):
     def natural_key(self):
         return (self.name,)
 
-    @memoized_method()
     def get_fields_with_groups(self) -> Generator[tuple["DataCheckerFieldset", "FlexField", str]]:
         fs: DataCheckerFieldset
         for fs in self.members.select_related("fieldset").all():
@@ -70,7 +69,6 @@ class DataChecker(ValidatorMixin, models.Model):
 
                 yield fs, field, effective_group
 
-    @memoized_method()
     def get_fields(self) -> Generator["FlexField"]:
         fs: DataCheckerFieldset
         for fs in self.members.select_related("fieldset").all():


### PR DESCRIPTION
When using @memoized_method on generator functions, the generator instance itself gets cached instead of the yielded data. As a result, the cached generator is exhausted after the first iteration, and subsequent calls to the decorated method yield nothing.