### PR TITLE
Do not allow field creation with a duplicated name via admin

### DIFF
--- a/src/hope_flex_fields/admin/fieldset.py
+++ b/src/hope_flex_fields/admin/fieldset.py
@@ -69,6 +69,7 @@ class FieldsetAdmin(ExtraButtonsMixin, ModelAdmin):
         )
         if request.method == "POST":
             formset = FieldFormset(request.POST, instance=fs)
+            self._check_duplicate_names_in_formset_forms(formset, fs)
             if formset.is_valid():
                 formset.save()
                 self.message_user(request, "Fields saved")
@@ -133,3 +134,15 @@ class FieldsetAdmin(ExtraButtonsMixin, ModelAdmin):
 
         ctx["form"] = form
         return render(request, "flex_fields/test.html", ctx)
+
+    @staticmethod
+    def _check_duplicate_names_in_formset_forms(formset, fieldset: Fieldset):
+        existing_field_names = fieldset.get_fieldnames()
+        for form in formset.forms:
+            if (
+                form.instance.pk is None
+                and not form["DELETE"].value()
+                and (name := form["name"].value())
+                and name in existing_field_names
+            ):
+                form.add_error("name", "Field with this name already exists in the fieldset.")

--- a/tests/admin/test_admin_fieldset.py
+++ b/tests/admin/test_admin_fieldset.py
@@ -83,3 +83,26 @@ def test_all_fields_method_inlineformset_factory(app, record):
     res = app.get(url)
     assert res.status_code == 200
     assert "formset" in res.context
+
+
+def test_all_fields_duplicate_name_validation(app, record):
+    url = reverse("admin:hope_flex_fields_fieldset_all_fields", args=[record.pk])
+
+    res = app.get(url)
+    assert res.status_code == 200
+
+    form = None
+    for f in res.forms.values():
+        if "fields-INITIAL_FORMS" in f.fields:
+            form = f
+            break
+
+    assert form is not None
+    initial_forms = int(form["fields-INITIAL_FORMS"].value)
+    new_form_idx = initial_forms
+    form[f"fields-{new_form_idx}-name"] = "int"
+
+    res = form.submit()
+
+    assert res.status_code == 200
+    assert b"Field with this name already exists in the fieldset." in res.content


### PR DESCRIPTION
AB#289999

Iterate over each form within fieldset formset and check if requested name already exists. Add error to the form if this is the case