### PR TITLE
298132: Add IdentityField for collision detection and enforce uniquen…

### DIFF
--- a/src/hope_flex_fields/admin/datachecker.py
+++ b/src/hope_flex_fields/admin/datachecker.py
@@ -13,6 +13,7 @@ from django.utils.translation import gettext_lazy as _
 from admin_extra_buttons.decorators import button
 from admin_extra_buttons.mixins import ExtraButtonsMixin
 
+from ..fields import IdentityField
 from ..file_handlers import HANDLERS
 from ..forms import DataCheckerFieldsetForm
 from ..models import DataChecker, DataCheckerFieldset, Fieldset
@@ -43,8 +44,12 @@ class FileForm(forms.Form):
 class DataCheckerFieldsetFormset(forms.models.BaseInlineFormSet):
     def clean(self):
         all_fields = set()
+        identity_field_count = 0
         fs: Fieldset
         for form in self.forms:
+            if form.cleaned_data.get("DELETE"):
+                continue
+
             if fs := form.cleaned_data.get("fieldset"):
                 prefix: str = form.cleaned_data["prefix"]
                 if "%s" in prefix:
@@ -54,6 +59,13 @@ class DataCheckerFieldsetFormset(forms.models.BaseInlineFormSet):
                 if all_fields.intersection(fs_fields):
                     raise forms.ValidationError("Field names are not unique")
                 all_fields.update(fs_fields)
+
+                for field in fs.get_fields():
+                    if issubclass(field.definition.field_type, IdentityField):
+                        identity_field_count += 1
+
+        if identity_field_count > 1:
+            raise forms.ValidationError("Only one IdentityField is allowed per DataChecker.")
 
 
 class DataCheckerFieldsetTabularInline(TabularInline):

--- a/src/hope_flex_fields/fields.py
+++ b/src/hope_flex_fields/fields.py
@@ -8,3 +8,13 @@ if TYPE_CHECKING:
 
 class FlexFormMixin(forms.Field):
     flex_field: "FlexField" = None
+
+
+class IdentityField(forms.CharField):
+    """Marks a record's identity for collision detection.
+
+    Rules enforced by the system:
+    - At most one IdentityField may exist per DataChecker.
+    - During validation, values are automatically checked for uniqueness
+      across the dataset (duplicate values produce a validation error).
+    """

--- a/src/hope_flex_fields/migrations/0016_add_identityfield.py
+++ b/src/hope_flex_fields/migrations/0016_add_identityfield.py
@@ -1,0 +1,19 @@
+# Generated migration to add IdentityField to the default FieldDefinition catalogue.
+# create_default_fields uses get_or_create so running it again is safe and idempotent.
+
+from django.db import migrations
+
+from hope_flex_fields.utils import create_default_fields
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        (
+            "hope_flex_fields",
+            "0015_alter_datachecker_id_alter_datacheckerfieldset_id_and_more",
+        ),
+    ]
+
+    operations = [
+        migrations.RunPython(create_default_fields, migrations.RunPython.noop),
+    ]

--- a/src/hope_flex_fields/models/base.py
+++ b/src/hope_flex_fields/models/base.py
@@ -132,11 +132,20 @@ class ValidatorMixin:
         include_success: bool = False,
         fail_if_alien: bool = False,
     ):
+        from ..fields import IdentityField
+
         if not isinstance(data, list | tuple | Generator):
             data = [data]
         self.primary_keys = set()
+
+        self._primary_key_field_name = None
         form_class: type[FlexForm] = self.get_form_class()
         known_fields = set(form_class.declared_fields.keys())
+        for field_name, field_instance in form_class.declared_fields.items():
+            if isinstance(field_instance, IdentityField):
+                self.set_primary_key_col(field_name)
+                break
+
         ret = {}
         for i, row in enumerate(data, 1):
             self.form: "FlexForm" = form_class(data=row, initial=row)

--- a/src/hope_flex_fields/models/base.py
+++ b/src/hope_flex_fields/models/base.py
@@ -137,14 +137,16 @@ class ValidatorMixin:
         if not isinstance(data, list | tuple | Generator):
             data = [data]
         self.primary_keys = set()
-
-        self._primary_key_field_name = None
         form_class: type[FlexForm] = self.get_form_class()
         known_fields = set(form_class.declared_fields.keys())
-        for field_name, field_instance in form_class.declared_fields.items():
-            if isinstance(field_instance, IdentityField):
-                self.set_primary_key_col(field_name)
-                break
+        # Auto-detect IdentityField only when no primary key column was manually
+        # configured via set_primary_key_col().  This preserves the existing
+        # master-detail pattern where callers set the column explicitly.
+        if not self._primary_key_field_name:
+            for field_name, field_instance in form_class.declared_fields.items():
+                if isinstance(field_instance, IdentityField):
+                    self.set_primary_key_col(field_name)
+                    break
 
         ret = {}
         for i, row in enumerate(data, 1):

--- a/src/hope_flex_fields/registry.py
+++ b/src/hope_flex_fields/registry.py
@@ -3,6 +3,8 @@ from django import forms
 from strategy_field.registry import Registry
 from strategy_field.utils import fqn, import_by_name
 
+from .fields import IdentityField
+
 
 class FieldRegistry(Registry):
     def get_name(self, entry):
@@ -63,3 +65,4 @@ field_registry.register(forms.TimeField)
 field_registry.register(forms.URLField)
 field_registry.register(forms.UUIDField)
 field_registry.register(forms.JSONField)
+field_registry.register(IdentityField)

--- a/tests/admin/test_admin_checker.py
+++ b/tests/admin/test_admin_checker.py
@@ -325,3 +325,44 @@ def test_datachecker_single_identity_field_accepted(app, two_identity_fieldsets)
     res = res.forms["datachecker_form"].submit()
 
     assert res.status_code in (200, 302)
+
+
+@pytest.fixture
+def dc_with_two_identity_members(db):
+    """DataChecker that already has two IdentityField members saved via factory
+    (bypasses admin formset validation so the conflicting state can exist)."""
+    from testutils.factories import (
+        DataCheckerFactory,
+        DataCheckerFieldsetFactory,
+        FieldDefinitionFactory,
+        FieldsetFactory,
+        FlexFieldFactory,
+    )
+
+    fd_id = FieldDefinitionFactory(field_type=IdentityField)
+    fs1 = FieldsetFactory(name="IDSet-A")
+    fs2 = FieldsetFactory(name="IDSet-B")
+    FlexFieldFactory(name="uid_a", definition=fd_id, fieldset=fs1, attrs={"required": False})
+    FlexFieldFactory(name="uid_b", definition=fd_id, fieldset=fs2, attrs={"required": False})
+
+    dc = DataCheckerFactory()
+    DataCheckerFieldsetFactory(checker=dc, fieldset=fs1, prefix="a_")
+    DataCheckerFieldsetFactory(checker=dc, fieldset=fs2, prefix="b_")
+    return dc
+
+
+def test_datachecker_deleted_inline_skips_identity_check(app, dc_with_two_identity_members):
+    """A formset row marked for DELETE is skipped by DataCheckerFieldsetFormset.clean().
+
+    Without the ``continue`` the two IdentityField members would trigger the
+    'Only one IdentityField is allowed' error even though one is being removed.
+    """
+    dc = dc_with_two_identity_members
+    url = reverse("admin:hope_flex_fields_datachecker_change", args=[dc.pk])
+    res = app.get(url)
+    # Mark the first existing member for deletion — clean() must skip it.
+    res.forms["datachecker_form"]["members-0-DELETE"] = True
+    res = res.forms["datachecker_form"].submit()
+
+    assert b"Only one IdentityField is allowed per DataChecker" not in res.content
+    assert res.status_code in (200, 302)

--- a/tests/admin/test_admin_checker.py
+++ b/tests/admin/test_admin_checker.py
@@ -1,12 +1,14 @@
 from pathlib import Path
 
 from django import forms
+from django.core.exceptions import ValidationError
 from django.urls import reverse
 
 import pytest
 from testutils.factories import DataCheckerFactory
 from webtest import Upload
 
+from hope_flex_fields.fields import IdentityField
 from hope_flex_fields.models import Fieldset
 
 pytestmark = [pytest.mark.admin, pytest.mark.smoke, pytest.mark.django_db]
@@ -250,3 +252,74 @@ def test_datachecker_validate_xls(app, rdi):
     res.forms["validate-form"]["file"] = Upload("rdi.xlsx", data)
     res = res.forms["validate-form"].submit()
     assert res.status_code == 200
+
+
+# ── ValidatableFileValidator unit tests ──────────────────────────────────────
+
+def test_validatable_file_validator_accepts_supported_format():
+    """No error is raised for a file whose extension is in HANDLERS."""
+    from hope_flex_fields.admin.datachecker import ValidatableFileValidator
+
+    validator = ValidatableFileValidator()
+
+    class _File:
+        name = "data.xlsx"
+
+    validator(_File())  # must not raise
+
+
+def test_validatable_file_validator_rejects_unsupported_format():
+    """ValidationError is raised for a file whose extension is not in HANDLERS."""
+    from hope_flex_fields.admin.datachecker import ValidatableFileValidator
+
+    validator = ValidatableFileValidator()
+
+    class _File:
+        name = "data.csv"
+
+    with pytest.raises(ValidationError):
+        validator(_File())
+
+
+# ── IdentityField enforcement in DataCheckerFieldsetFormset ──────────────────
+
+@pytest.fixture
+def two_identity_fieldsets(db):
+    """Two fieldsets that each contain one IdentityField flex-field."""
+    from testutils.factories import FieldDefinitionFactory, FieldsetFactory, FlexFieldFactory
+
+    fd_id = FieldDefinitionFactory(field_type=IdentityField)
+    fs1 = FieldsetFactory(name="IDFieldset1")
+    fs2 = FieldsetFactory(name="IDFieldset2")
+    FlexFieldFactory(name="uid1", definition=fd_id, fieldset=fs1, attrs={"required": False})
+    FlexFieldFactory(name="uid2", definition=fd_id, fieldset=fs2, attrs={"required": False})
+    return fs1, fs2
+
+
+def test_datachecker_multiple_identity_fields_rejected(app, two_identity_fieldsets):
+    """Saving a DataChecker with two IdentityFields across its fieldsets is rejected."""
+    fs1, fs2 = two_identity_fieldsets
+    url = reverse("admin:hope_flex_fields_datachecker_add")
+    res = app.get(url)
+    res.forms["datachecker_form"]["name"] = "DC-MultiID"
+    res.forms["datachecker_form"]["members-0-fieldset"] = fs1.pk
+    res.forms["datachecker_form"]["members-0-prefix"] = "a_"
+    res.forms["datachecker_form"]["members-1-fieldset"] = fs2.pk
+    res.forms["datachecker_form"]["members-1-prefix"] = "b_"
+    res = res.forms["datachecker_form"].submit()
+
+    assert res.status_code == 200
+    assert b"Only one IdentityField is allowed per DataChecker" in res.content
+
+
+def test_datachecker_single_identity_field_accepted(app, two_identity_fieldsets):
+    """Saving a DataChecker with exactly one IdentityField across its fieldsets succeeds."""
+    fs1, _fs2 = two_identity_fieldsets
+    url = reverse("admin:hope_flex_fields_datachecker_add")
+    res = app.get(url)
+    res.forms["datachecker_form"]["name"] = "DC-SingleID"
+    res.forms["datachecker_form"]["members-0-fieldset"] = fs1.pk
+    res.forms["datachecker_form"]["members-0-prefix"] = "a_"
+    res = res.forms["datachecker_form"].submit()
+
+    assert res.status_code in (200, 302)

--- a/tests/admin/test_admin_checker.py
+++ b/tests/admin/test_admin_checker.py
@@ -256,6 +256,7 @@ def test_datachecker_validate_xls(app, rdi):
 
 # ── ValidatableFileValidator unit tests ──────────────────────────────────────
 
+
 def test_validatable_file_validator_accepts_supported_format():
     """No error is raised for a file whose extension is in HANDLERS."""
     from hope_flex_fields.admin.datachecker import ValidatableFileValidator
@@ -282,6 +283,7 @@ def test_validatable_file_validator_rejects_unsupported_format():
 
 
 # ── IdentityField enforcement in DataCheckerFieldsetFormset ──────────────────
+
 
 @pytest.fixture
 def two_identity_fieldsets(db):

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -1,3 +1,7 @@
+import pytest
+from django import forms
+
+from hope_flex_fields.fields import IdentityField
 from hope_flex_fields.models.base import ValidatorMixin
 
 
@@ -34,3 +38,59 @@ def test_collected_values_handling():
 
     assert validator.collected("field1") == ["value1"]
     assert validator.collected("field2") == ["value2"]
+
+
+@pytest.mark.django_db
+def test_identity_field_auto_detected_as_pk():
+    """validate() discovers an IdentityField in the form and uses it as the PK column."""
+    from testutils.factories import FieldDefinitionFactory, FieldsetFactory, FlexFieldFactory
+
+    fd_uid = FieldDefinitionFactory(field_type=IdentityField)
+    fd_name = FieldDefinitionFactory(field_type=forms.CharField)
+    fs = FieldsetFactory()
+    FlexFieldFactory(name="uid", definition=fd_uid, fieldset=fs, attrs={"required": False})
+    FlexFieldFactory(name="name", definition=fd_name, fieldset=fs, attrs={"required": False})
+
+    data = [{"uid": "A1", "name": "Alice"}, {"uid": "A2", "name": "Bob"}]
+    errors = fs.validate(data)
+
+    assert errors == {}
+    assert fs._primary_key_field_name == "uid"
+
+
+@pytest.mark.django_db
+def test_identity_field_duplicate_detected():
+    """validate() reports a duplicate error when two rows share the same IdentityField value."""
+    from testutils.factories import FieldDefinitionFactory, FieldsetFactory, FlexFieldFactory
+
+    fd_uid = FieldDefinitionFactory(field_type=IdentityField)
+    fd_name = FieldDefinitionFactory(field_type=forms.CharField)
+    fs = FieldsetFactory()
+    FlexFieldFactory(name="uid", definition=fd_uid, fieldset=fs, attrs={"required": False})
+    FlexFieldFactory(name="name", definition=fd_name, fieldset=fs, attrs={"required": False})
+
+    data = [{"uid": "X1", "name": "Alice"}, {"uid": "X1", "name": "Bob"}]
+    errors = fs.validate(data)
+
+    assert 2 in errors
+    assert errors[2]["-"] == ["X1 duplicated"]
+
+
+@pytest.mark.django_db
+def test_explicit_pk_not_overridden_by_identity_field():
+    """set_primary_key_col() takes precedence — IdentityField auto-detection is skipped."""
+    from testutils.factories import FieldDefinitionFactory, FieldsetFactory, FlexFieldFactory
+
+    fd_uid = FieldDefinitionFactory(field_type=IdentityField)
+    fd_seq = FieldDefinitionFactory(field_type=forms.IntegerField)
+    fs = FieldsetFactory()
+    FlexFieldFactory(name="uid", definition=fd_uid, fieldset=fs, attrs={"required": False})
+    FlexFieldFactory(name="seq", definition=fd_seq, fieldset=fs, attrs={"required": False})
+
+    fs.set_primary_key_col("seq")
+    # uid is duplicated but seq is the explicit PK, so no duplicate error
+    data = [{"uid": "SAME", "seq": 1}, {"uid": "SAME", "seq": 2}]
+    errors = fs.validate(data)
+
+    assert errors == {}
+    assert fs._primary_key_field_name == "seq"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -79,4 +79,4 @@ def test_sync(admin_user, data, mocked_responses):
     mocked_responses.get("http://testserver/api/sync/", json=data)
     response = client.get("http://testserver/api/sync/")
     out = loaddata_from_buffer(response)
-    assert "Processed 33 object(s).\nInstalled 33 object(s) from 1 fixture(s)" in out
+    assert "Processed 34 object(s).\nInstalled 34 object(s) from 1 fixture(s)" in out


### PR DESCRIPTION
…ess in DataChecker

- Introduced IdentityField to mark a record's identity, ensuring only one instance per DataChecker.
- Updated DataCheckerFieldsetFormset to validate the uniqueness of IdentityField across datasets.
- Registered IdentityField in FieldRegistry for proper integration.
- Adjusted ValidatorMixin to recognize IdentityField as the primary key field.

AB#298132