### PR TITLE
320213: Add file handling capabilities to DataChecker and FlexField

### DIFF
--- a/src/hope_flex_fields/models/datachecker.py
+++ b/src/hope_flex_fields/models/datachecker.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 from django.db import models
 from django.utils.translation import gettext as _
 
@@ -118,6 +118,41 @@ class DataChecker(ValidatorMixin, models.Model):
         }
 
         return type(f"{self.name}DataCheckerForm", (FlexForm,), form_class_attrs)
+
+    def get_file_field_names(self, *, with_prefix: bool = True) -> set[str]:
+        """Return the (optionally prefixed) names of fields that hold file data.
+
+        The names match those produced by :meth:`get_form_class`, so callers can
+        use them to key into cleaned/validated data.
+        """
+        names: set[str] = set()
+        field: "FlexField"
+        for fs, field in self.get_fields():
+            if not field.is_file:
+                continue
+            if "%s" in fs.prefix:
+                full_name = fs.prefix % field.name
+            else:
+                full_name = f"{fs.prefix}{field.name}"
+            names.add(full_name if with_prefix else field.name)
+        return names
+
+    def split_data(self, data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+        """Split a data mapping into text ``fields`` and binary ``files``.
+
+        The distinction is driven by each flex field's ``is_file`` attribute, so
+        every consumer gets a consistent text/file separation without having to
+        know how field types are configured.
+        """
+        file_names = self.get_file_field_names()
+        fields: dict[str, Any] = {}
+        files: dict[str, Any] = {}
+        for key, value in data.items():
+            if key in file_names:
+                files[key] = value
+            else:
+                fields[key] = value
+        return {"fields": fields, "files": files}
 
 
 def create_xls_importer(dc: "DataChecker") -> BytesIO:

--- a/src/hope_flex_fields/models/flexfield.py
+++ b/src/hope_flex_fields/models/flexfield.py
@@ -62,10 +62,7 @@ class FlexField(AbstractField):
         Used by the data checker to route cleaned values into the proper
         storage (text fields vs. file blob).
         """
-        try:
-            return isinstance(self.get_field(), forms.FileField)
-        except FlexFieldCreationError:
-            return False
+        return issubclass(self.definition.field_type, forms.FileField)
 
     def validate_attrs(self):
         try:

--- a/src/hope_flex_fields/models/flexfield.py
+++ b/src/hope_flex_fields/models/flexfield.py
@@ -54,6 +54,20 @@ class FlexField(AbstractField):
     def base_type(self):
         return self.definition.field_type.__name__
 
+    @property
+    def is_file(self) -> bool:
+        """Whether this field stores binary/file data rather than text.
+
+        Used by the data checker to route cleaned values into the proper
+        storage (text fields vs. file blob).
+        """
+        from django import forms
+
+        try:
+            return isinstance(self.get_field(), forms.FileField)
+        except FlexFieldCreationError:
+            return False
+
     def validate_attrs(self):
         try:
             self.get_field()

--- a/src/hope_flex_fields/models/flexfield.py
+++ b/src/hope_flex_fields/models/flexfield.py
@@ -1,5 +1,6 @@
 import logging
 
+from django import forms
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import UniqueConstraint
@@ -61,8 +62,6 @@ class FlexField(AbstractField):
         Used by the data checker to route cleaned values into the proper
         storage (text fields vs. file blob).
         """
-        from django import forms
-
         try:
             return isinstance(self.get_field(), forms.FileField)
         except FlexFieldCreationError:

--- a/tests/models/test_model_datacheker.py
+++ b/tests/models/test_model_datacheker.py
@@ -58,6 +58,16 @@ def test_flexfield_is_file_flag(file_and_text_fieldset):
     assert fields == {"photo": True, "full_name": False}
 
 
+def test_flexfield_is_file_false_when_field_cannot_be_built(db):
+    from unittest.mock import patch
+
+    from hope_flex_fields.exceptions import FlexFieldCreationError
+
+    field = FlexFieldFactory()
+    with patch.object(field, "get_field", side_effect=FlexFieldCreationError("boom")):
+        assert field.is_file is False
+
+
 @pytest.mark.parametrize(
     ("prefix", "expected"),
     [("", "photo"), ("member_", "member_photo"), ("%s_", "photo_")],

--- a/tests/models/test_model_datacheker.py
+++ b/tests/models/test_model_datacheker.py
@@ -1,9 +1,7 @@
 import pytest
-from unittest.mock import patch
 
 from django import forms
 
-from hope_flex_fields.exceptions import FlexFieldCreationError
 from hope_flex_fields.registry import field_registry
 
 from testutils.factories import (
@@ -60,12 +58,6 @@ def file_and_text_fieldset(db):
 def test_flexfield_is_file_flag(file_and_text_fieldset):
     fields = {f.name: f.is_file for f in file_and_text_fieldset.get_fields()}
     assert fields == {"photo": True, "full_name": False}
-
-
-def test_flexfield_is_file_false_when_field_cannot_be_built(db):
-    field = FlexFieldFactory()
-    with patch.object(field, "get_field", side_effect=FlexFieldCreationError("boom")):
-        assert field.is_file is False
 
 
 @pytest.mark.parametrize(

--- a/tests/models/test_model_datacheker.py
+++ b/tests/models/test_model_datacheker.py
@@ -1,5 +1,9 @@
 import pytest
+from unittest.mock import patch
+
 from django import forms
+
+from hope_flex_fields.exceptions import FlexFieldCreationError
 from hope_flex_fields.registry import field_registry
 
 from testutils.factories import (
@@ -59,10 +63,6 @@ def test_flexfield_is_file_flag(file_and_text_fieldset):
 
 
 def test_flexfield_is_file_false_when_field_cannot_be_built(db):
-    from unittest.mock import patch
-
-    from hope_flex_fields.exceptions import FlexFieldCreationError
-
     field = FlexFieldFactory()
     with patch.object(field, "get_field", side_effect=FlexFieldCreationError("boom")):
         assert field.is_file is False

--- a/tests/models/test_model_datacheker.py
+++ b/tests/models/test_model_datacheker.py
@@ -1,5 +1,6 @@
 import pytest
 from django import forms
+from hope_flex_fields.registry import field_registry
 
 from testutils.factories import (
     DataCheckerFactory,
@@ -41,8 +42,6 @@ def test_datachecker_fieldset_specs_map_matches_form_field_names(fs, prefix: str
 
 @pytest.fixture
 def file_and_text_fieldset(db):
-    from hope_flex_fields.registry import field_registry
-
     if forms.FileField not in field_registry:
         field_registry.register(forms.FileField)
 

--- a/tests/models/test_model_datacheker.py
+++ b/tests/models/test_model_datacheker.py
@@ -37,3 +37,48 @@ def test_datachecker_fieldset_specs_map_matches_form_field_names(fs, prefix: str
     assert bare_to_prefixed == expected
     assert expected["document_number"] in form_class.base_fields
     assert expected["country"] in form_class.base_fields
+
+
+@pytest.fixture
+def file_and_text_fieldset(db):
+    from hope_flex_fields.registry import field_registry
+
+    if forms.FileField not in field_registry:
+        field_registry.register(forms.FileField)
+
+    file_def = FieldDefinitionFactory(field_type=forms.FileField, attrs={"required": False})
+    text_def = FieldDefinitionFactory(field_type=forms.CharField, attrs={"required": False})
+    fs = FieldsetFactory()
+    FlexFieldFactory(name="photo", definition=file_def, fieldset=fs)
+    FlexFieldFactory(name="full_name", definition=text_def, fieldset=fs)
+    return fs
+
+
+def test_flexfield_is_file_flag(file_and_text_fieldset):
+    fields = {f.name: f.is_file for f in file_and_text_fieldset.get_fields()}
+    assert fields == {"photo": True, "full_name": False}
+
+
+@pytest.mark.parametrize(
+    ("prefix", "expected"),
+    [("", "photo"), ("member_", "member_photo"), ("%s_", "photo_")],
+    ids=["no_prefix", "concat_prefix", "template_suffix"],
+)
+def test_datachecker_get_file_field_names(file_and_text_fieldset, prefix: str, expected: str):
+    dc = DataCheckerFactory()
+    DataCheckerFieldsetFactory(checker=dc, fieldset=file_and_text_fieldset, prefix=prefix, order=0)
+
+    assert dc.get_file_field_names() == {expected}
+    assert dc.get_file_field_names(with_prefix=False) == {"photo"}
+
+
+def test_datachecker_split_data_separates_files_from_text(file_and_text_fieldset):
+    dc = DataCheckerFactory()
+    DataCheckerFieldsetFactory(checker=dc, fieldset=file_and_text_fieldset, prefix="", order=0)
+
+    split = dc.split_data({"full_name": "Jane", "photo": "blob", "extra": "x"})
+
+    assert split == {
+        "fields": {"full_name": "Jane", "extra": "x"},
+        "files": {"photo": "blob"},
+    }


### PR DESCRIPTION
- Introduced `is_file` property in `FlexField` to identify binary/file data fields.
- Added `get_file_field_names` method in `DataChecker` to retrieve names of fields that hold file data.
- Implemented `split_data` method in `DataChecker` to separate text fields from file fields in a given data mapping.
- Enhanced tests to verify the new functionality for file and text field handling.