### PR TITLE
Enhance DataChecker's split_data method to accept optional file field…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ requires = [
 
 [project]
 name = "hope-flex-fields"
-dynamic = ["version"]
 description = ""
 readme = "README.md"
 license = { text = "MIT" }
@@ -28,6 +27,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
 ]
+dynamic = [ "version" ]
 dependencies = [
   "deepdiff",
   "deprecation",

--- a/src/hope_flex_fields/models/datachecker.py
+++ b/src/hope_flex_fields/models/datachecker.py
@@ -9,7 +9,7 @@ from ..utils import memoized_method
 from ..xlsx import get_format_for_field, get_validation_for_field
 from .base import ValidatorMixin
 from .fieldset import Fieldset
-from collections.abc import Generator  # noqa: TC003
+from collections.abc import Collection, Generator  # noqa: TC003
 
 if TYPE_CHECKING:
     from xlsxwriter import Format, Workbook
@@ -119,6 +119,7 @@ class DataChecker(ValidatorMixin, models.Model):
 
         return type(f"{self.name}DataCheckerForm", (FlexForm,), form_class_attrs)
 
+    @memoized_method()
     def get_file_field_names(self, *, with_prefix: bool = True) -> set[str]:
         """Return the (optionally prefixed) names of fields that hold file data.
 
@@ -137,14 +138,19 @@ class DataChecker(ValidatorMixin, models.Model):
             names.add(full_name if with_prefix else field.name)
         return names
 
-    def split_data(self, data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    def split_data(
+        self,
+        data: dict[str, Any],
+        *,
+        file_field_names: Collection[str] | None = None,
+    ) -> dict[str, dict[str, Any]]:
         """Split a data mapping into text ``fields`` and binary ``files``.
 
         The distinction is driven by each flex field's ``is_file`` attribute, so
         every consumer gets a consistent text/file separation without having to
         know how field types are configured.
         """
-        file_names = self.get_file_field_names()
+        file_names = set(file_field_names) if file_field_names is not None else self.get_file_field_names()
         fields: dict[str, Any] = {}
         files: dict[str, Any] = {}
         for key, value in data.items():

--- a/tests/models/test_model_datacheker.py
+++ b/tests/models/test_model_datacheker.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import patch
 
 from django import forms
 
@@ -85,17 +86,15 @@ def test_datachecker_split_data_separates_files_from_text(file_and_text_fieldset
     }
 
 
-def test_datachecker_split_data_uses_provided_file_names(file_and_text_fieldset, mocker):
+def test_datachecker_split_data_uses_provided_file_names(file_and_text_fieldset):
     dc = DataCheckerFactory()
     DataCheckerFieldsetFactory(checker=dc, fieldset=file_and_text_fieldset, prefix="", order=0)
-    get_file_field_names = mocker.patch.object(dc, "get_file_field_names")
-
-    split = dc.split_data(
-        {"full_name": "Jane", "photo": "blob", "extra": "x"},
-        file_field_names={"photo"},
-    )
-
-    get_file_field_names.assert_not_called()
+    with patch.object(dc, "get_file_field_names") as get_file_field_names:
+        split = dc.split_data(
+            {"full_name": "Jane", "photo": "blob", "extra": "x"},
+            file_field_names={"photo"},
+        )
+        get_file_field_names.assert_not_called()
     assert split == {
         "fields": {"full_name": "Jane", "extra": "x"},
         "files": {"photo": "blob"},

--- a/tests/models/test_model_datacheker.py
+++ b/tests/models/test_model_datacheker.py
@@ -83,3 +83,20 @@ def test_datachecker_split_data_separates_files_from_text(file_and_text_fieldset
         "fields": {"full_name": "Jane", "extra": "x"},
         "files": {"photo": "blob"},
     }
+
+
+def test_datachecker_split_data_uses_provided_file_names(file_and_text_fieldset, mocker):
+    dc = DataCheckerFactory()
+    DataCheckerFieldsetFactory(checker=dc, fieldset=file_and_text_fieldset, prefix="", order=0)
+    get_file_field_names = mocker.patch.object(dc, "get_file_field_names")
+
+    split = dc.split_data(
+        {"full_name": "Jane", "photo": "blob", "extra": "x"},
+        file_field_names={"photo"},
+    )
+
+    get_file_field_names.assert_not_called()
+    assert split == {
+        "fields": {"full_name": "Jane", "extra": "x"},
+        "files": {"photo": "blob"},
+    }


### PR DESCRIPTION
… names

- Updated the `split_data` method to allow passing a collection of file field names, improving flexibility in data separation.
- Added a memoized method `get_file_field_names` to optimize retrieval of file field names.
- Introduced a new test to verify that `split_data` correctly uses provided file field names without calling `get_file_field_names`.